### PR TITLE
ユーザー情報の取得をログイン時にできるように

### DIFF
--- a/Lovendar/Auth/AuthViewModel.swift
+++ b/Lovendar/Auth/AuthViewModel.swift
@@ -28,8 +28,7 @@ class AuthViewModel: ObservableObject {
             if isLoginMode {
                 // ログイン
                 let response = try await authService.login(email: email, password: password)
-                let user = User(id: nil, name: "", email: email)
-                await authManager.login(token: response.token, user: user)
+                try await authManager.login(token: response.token)
             } else {
                 // 新規登録
                 guard isPasswordValid else {
@@ -39,8 +38,7 @@ class AuthViewModel: ObservableObject {
                 }
                 
                 let response = try await authService.register(name: name, email: email, password: password)
-                let user = User(id: nil, name: response.name, email: response.email)
-                await authManager.login(token: response.token, user: user)
+                try await authManager.login(token: response.token)
             }
         } catch let error as NetworkError {
             errorMessage = error.localizedDescription

--- a/Lovendar/Calendar/CalendarView.swift
+++ b/Lovendar/Calendar/CalendarView.swift
@@ -276,36 +276,13 @@ struct CalendarView: View {
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
                     
-                    // API接続状況の表示
-                    HStack(spacing: 8) {
-                        Circle()
-                            .fill(apiConfig.isConnected ? Color.green : Color.red)
-                            .frame(width: 8, height: 8)
-                        Text("API: \(apiConfig.currentEnvironment.displayName)")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                        Text(apiConfig.isConnected ? "接続中" : "未接続")
-                            .font(.caption2)
-                            .foregroundColor(apiConfig.isConnected ? .green : .red)
-                    }
-                    
-                    HStack(spacing: 16) {
-                        Button("接続テスト") {
-                            Task {
-                                await apiConfig.testConnection()
-                            }
+                    Button("再試行") {
+                        Task {
+                            await refreshData()
                         }
-                        .font(.caption)
-                        .foregroundColor(.blue)
-                        
-                        Button("再試行") {
-                            Task {
-                                await refreshData()
-                            }
-                        }
-                        .font(.caption)
-                        .foregroundColor(themeManager.currentTheme.primaryColor)
                     }
+                    .font(.caption)
+                    .foregroundColor(themeManager.currentTheme.primaryColor)
                 }
                 .padding(.horizontal)
                 .padding(.bottom)
@@ -376,36 +353,13 @@ struct CalendarView: View {
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
                     
-                    // API接続状況の表示
-                    HStack(spacing: 8) {
-                        Circle()
-                            .fill(apiConfig.isConnected ? Color.green : Color.red)
-                            .frame(width: 8, height: 8)
-                        Text("API: \(apiConfig.currentEnvironment.displayName)")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                        Text(apiConfig.isConnected ? "接続中" : "未接続")
-                            .font(.caption2)
-                            .foregroundColor(apiConfig.isConnected ? .green : .red)
-                    }
-                    
-                    HStack(spacing: 16) {
-                        Button("接続テスト") {
-                            Task {
-                                await apiConfig.testConnection()
-                            }
+                    Button("再試行") {
+                        Task {
+                            await refreshData()
                         }
-                        .font(.caption)
-                        .foregroundColor(.blue)
-                        
-                        Button("再試行") {
-                            Task {
-                                await refreshData()
-                            }
-                        }
-                        .font(.caption)
-                        .foregroundColor(themeManager.currentTheme.primaryColor)
                     }
+                    .font(.caption)
+                    .foregroundColor(themeManager.currentTheme.primaryColor)
                 }
                 .padding(.horizontal)
                 .padding(.bottom)

--- a/Lovendar/Calendar/CalendarViewModel.swift
+++ b/Lovendar/Calendar/CalendarViewModel.swift
@@ -238,29 +238,8 @@ class CalendarViewModel: ObservableObject {
         await loadEvents()
     }
     
-    // 詳細なエラーメッセージを生成
+    // 簡略化されたエラーメッセージを生成
     private func getDetailedErrorMessage(_ error: Error) -> String {
-        if let nsError = error as NSError? {
-            switch nsError.code {
-            case NSURLErrorCancelled:
-                return "リクエストがキャンセルされました。もう一度お試しください。"
-            case NSURLErrorTimedOut:
-                return "接続がタイムアウトしました。ネットワーク接続を確認してください。"
-            case NSURLErrorCannotConnectToHost:
-                return "サーバーに接続できません。APIサーバーが起動しているか確認してください。"
-            case NSURLErrorNotConnectedToInternet:
-                return "インターネット接続がありません。"
-            case NSURLErrorNetworkConnectionLost:
-                return "ネットワーク接続が失われました。"
-            default:
-                return "ネットワークエラーが発生しました: \(nsError.localizedDescription)"
-            }
-        }
-        
-        if let networkError = error as? NetworkError {
-            return networkError.localizedDescription
-        }
-        
-        return "予期しないエラーが発生しました: \(error.localizedDescription)"
+        return "データの読み込みに失敗しました"
     }
 }

--- a/Lovendar/Core/APIService.swift
+++ b/Lovendar/Core/APIService.swift
@@ -10,6 +10,17 @@ class APIService {
     
     private init() {}
     
+    // MARK: - ユーザー情報関連
+    
+    // ユーザー情報取得
+    func getUserInfo() async throws -> UserInfoResponse {
+        return try await request<UserInfoResponse>(
+            endpoint: "/me",
+            method: .get,
+            requiresAuth: true
+        )
+    }
+    
     // 汎用リクエストメソッド
     func request<T: Decodable>(
         endpoint: String,

--- a/Lovendar/Core/AuthManager.swift
+++ b/Lovendar/Core/AuthManager.swift
@@ -23,7 +23,33 @@ class AuthManager: ObservableObject {
         return authToken
     }
     
-    // ログイン処理
+    // ログイン処理（トークンのみでユーザー情報をAPIから取得）
+    func login(token: String) async throws {
+        self.authToken = token
+        
+        // トークンを保存
+        UserDefaults.standard.set(token, forKey: tokenKey)
+        
+        // APIからユーザー情報を取得
+        do {
+            let userInfo = try await APIService.shared.getUserInfo()
+            let user = User(id: nil, name: userInfo.name, email: userInfo.email)
+            
+            self.currentUser = user
+            self.isAuthenticated = true
+            
+            // ユーザー情報を保存
+            if let encoded = try? JSONEncoder().encode(user) {
+                UserDefaults.standard.set(encoded, forKey: userKey)
+            }
+        } catch {
+            // ユーザー情報取得に失敗した場合はログアウト
+            self.logout()
+            throw error
+        }
+    }
+    
+    // 既存のログイン処理（後方互換性のため残す）
     func login(token: String, user: User) {
         self.authToken = token
         self.currentUser = user

--- a/Lovendar/Shared/APIModels.swift
+++ b/Lovendar/Shared/APIModels.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+// MARK: - ユーザー関連
+
+struct UserInfoResponse: Codable {
+    let name: String
+    let email: String
+}
+
 // MARK: - 共通情報
 
 struct CommonResponse: Codable {


### PR DESCRIPTION
## 概要
ユーザー情報を取得APIが存在していないことに気づき、BEに依頼、作成してもらったので、ログイン時にユーザー情報を取得するようにロジックを微妙に変更した。

そして、なぜかエラーメッセージがカレンダーのビューのところに発生しており見た目が良くないのでちょいとそれを表示しないように変更しました

## 動作確認
- 設定画面にユーザー名とメアドが表示されている
- ビルドエラーが発生していない
